### PR TITLE
Generally improve the design of the codebase

### DIFF
--- a/src/main/java/com/gamepedia/ftb/oredictdumper/OreDictDumperMod.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/OreDictDumperMod.java
@@ -1,18 +1,10 @@
 package com.gamepedia.ftb.oredictdumper;
 
-import com.gamepedia.ftb.oredictdumper.commands.*;
-import com.gamepedia.ftb.oredictdumper.misc.OreDictEntry;
+import com.gamepedia.ftb.oredictdumper.commands.DumpAllOresCommand;
+import com.gamepedia.ftb.oredictdumper.commands.DumpModOresCommand;
 import cpw.mods.fml.common.Mod;
-import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.registry.GameData;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.ClientCommandHandler;
-import net.minecraftforge.oredict.OreDictionary;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
 
 @Mod(modid = "oredictdumper", name = "OreDictDumper", version = "1.1.3")
 public class OreDictDumperMod {
@@ -20,42 +12,5 @@ public class OreDictDumperMod {
     public void registerCommand(FMLPostInitializationEvent event) {
         ClientCommandHandler.instance.registerCommand(new DumpModOresCommand());
         ClientCommandHandler.instance.registerCommand(new DumpAllOresCommand());
-    }
-
-    /**
-     * Returns an array of all the entries that are in the given mod ID.
-     * @param id The mod ID. Null if we don't want to narrow it down by mod ID (dumpallores)
-     * @return An array of OreDictEntries. Can be empty. Never null.
-     */
-    public static ArrayList<OreDictEntry> getEntries(@Nullable String id) {
-        ArrayList<OreDictEntry> entries = new ArrayList<>();
-        for (String name : OreDictionary.getOreNames()) {
-            for (ItemStack item : OreDictionary.getOres(name)) {
-                @SuppressWarnings("deprecation")
-                ModContainer mod = GameData.findModOwner(GameData.getItemRegistry().getNameForObject(item.getItem()));
-
-                String id1 = mod == null ? "minecraft" : mod.getModId();
-                if (id != null && !id.equals(id1)) {
-                    continue;
-                }
-
-                if (item.getItemDamage() == OreDictionary.WILDCARD_VALUE) {
-                    List list = new ArrayList();
-                    item.getItem().getSubItems(item.getItem(), null, list);
-                    for (Object obj : list) {
-                        // This will never happen assuming people are smart.
-                        if (!(obj instanceof ItemStack)) {
-                            continue;
-                        }
-                        ItemStack is = (ItemStack) obj;
-                        entries.add(new OreDictEntry(name, is.getDisplayName(), is.getItemDamage(), id1));
-                    }
-                } else {
-                    entries.add(new OreDictEntry(name, item.getDisplayName(), item.getItemDamage(), id1));
-                }
-            }
-        }
-
-        return entries;
     }
 }

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/commands/DumpAllOresCommand.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/commands/DumpAllOresCommand.java
@@ -1,111 +1,67 @@
 package com.gamepedia.ftb.oredictdumper.commands;
 
-import com.gamepedia.ftb.oredictdumper.OreDictDumperMod;
-import com.gamepedia.ftb.oredictdumper.misc.OreDictEntry;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import net.minecraft.client.Minecraft;
-import net.minecraft.command.ICommand;
-import net.minecraft.command.ICommandSender;
-import net.minecraft.command.WrongUsageException;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.StatCollector;
-import org.apache.commons.lang3.StringUtils;
+import com.gamepedia.ftb.oredictdumper.misc.OreDictOutputFormat;
+import com.google.common.collect.ImmutableList;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-public class DumpAllOresCommand implements ICommand {
-    public static final ArrayList<String> FORMATS = new ArrayList<String>() {{
-        add("json");
-        add("csv");
-    }};
+public class DumpAllOresCommand extends OreDumpCommandBase {
+    private static final ImmutableList<String> FORMATS = ImmutableList.of("json", "csv");
 
     @Override
     public String getCommandName() {
         return "dumpallores";
     }
 
+    @Nonnull
     @Override
-    public String getCommandUsage(ICommandSender sender) {
-        return StatCollector.translateToLocalFormatted("commands.dumpallores.usage", StringUtils.join(FORMATS, ','));
+    protected String getUnlocalizedCommandUsage() {
+        return "commands.dumpallores.usage";
     }
 
     @Override
-    public List getCommandAliases() {
+    protected int getFormatArgumentPosition() {
+        return 0;
+    }
+
+    @Nonnull
+    @Override
+    protected ImmutableList<String> getValidFormats() {
+        return FORMATS;
+    }
+
+    @Override
+    protected int getRequiredNumberOfArguments() {
+        return 1;
+    }
+
+    @Nonnull
+    @Override
+    protected String getOutputFileName(String[] args) {
+        return "oredump";
+    }
+
+    @Nullable
+    @Override
+    protected String getModIDToSearch(String[] args) {
         return null;
     }
 
+    @Nullable
     @Override
-    public void processCommand(ICommandSender sender, String[] args) {
-        if (!sender.getEntityWorld().isRemote) {
-            return;
-        }
-
-        if (args.length != 1) {
-            throw new WrongUsageException("commands.dumpallores.usage", StringUtils.join(FORMATS, ','));
-        }
-
-        String format = args[0].toLowerCase();
-
-        if (!FORMATS.contains(format)) {
-            throw new WrongUsageException("commands.dumpallores.usage", StringUtils.join(FORMATS, ','));
-        }
-
-        ArrayList<OreDictEntry> entries = OreDictDumperMod.getEntries(null);
-
-        File dir = new File(Minecraft.getMinecraft().mcDataDir, String.format("oredump.%s", format));
-        StringBuilder string = new StringBuilder("");
-
-        if (format.equals("json")) {
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
-            string.append(gson.toJson(entries));
-        } else if (format.equals("csv")) {
-            string.append("Tag,ItemName,Metadata,ModID\n");
-            for (OreDictEntry entry : entries) {
-                string.append(String.format("%s,%s,%s,%s\n", entry.tagName, entry.displayName, entry.metadata,
-                  entry.modID));
+    protected OreDictOutputFormat getOutputFormat(String[] args) {
+        String formatArg = args[getFormatArgumentPosition()];
+        switch (formatArg) {
+            case "json": {
+                return new OreDictOutputFormat.JSONOutputFormat();
+            }
+            case "csv": {
+                return new OreDictOutputFormat.CSVOutputFormat();
+            }
+            default: {
+                return null;
             }
         }
-
-        String msg;
-        try {
-            FileWriter writer = new FileWriter(dir);
-            writer.write(string.toString());
-            writer.close();
-            msg = EnumChatFormatting.GREEN + StatCollector.translateToLocalFormatted("commands.oredictdumpgeneric.success",
-              entries.size(), "oredump", format);
-        } catch (IOException e) {
-            e.printStackTrace();
-            System.out.println(entries.toString());
-            msg = EnumChatFormatting.RED + StatCollector.translateToLocal("commands.oredictdumpgeneric.ioexception");
-        }
-
-        sender.addChatMessage(new ChatComponentText(msg));
-    }
-
-    @Override
-    public boolean canCommandSenderUseCommand(ICommandSender sender) {
-        return true;
-    }
-
-    @Override
-    public List addTabCompletionOptions(ICommandSender sender, String[] options) {
-        return null;
-    }
-
-    @Override
-    public boolean isUsernameIndex(String[] p_82358_1_, int p_82358_2_) {
-        return false;
-    }
-
-    @SuppressWarnings("NullableProblems")
-    @Override
-    public int compareTo(Object o) {
-        return 0;
     }
 }

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/commands/DumpModOresCommand.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/commands/DumpModOresCommand.java
@@ -1,128 +1,70 @@
 package com.gamepedia.ftb.oredictdumper.commands;
 
-import com.gamepedia.ftb.oredictdumper.OreDictDumperMod;
-import com.gamepedia.ftb.oredictdumper.misc.OreDictEntry;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import net.minecraft.client.Minecraft;
-import net.minecraft.command.ICommand;
-import net.minecraft.command.ICommandSender;
-import net.minecraft.command.WrongUsageException;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.StatCollector;
+import com.gamepedia.ftb.oredictdumper.misc.OreDictOutputFormat;
+import com.google.common.collect.ImmutableList;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-public class DumpModOresCommand implements ICommand {
+public class DumpModOresCommand extends OreDumpCommandBase {
+    private static final ImmutableList<String> FORMATS = ImmutableList.of("csv", "json", "wiki");
+
     @Override
     public String getCommandName() {
         return "dumpmodores";
     }
 
+    @Nonnull
     @Override
-    public String getCommandUsage(ICommandSender sender) {
-        // TODO: This is ugly, do something similar to DumpAllOresCommand
-        return StatCollector.translateToLocalFormatted("commands.dumpmodores.usage", "wiki,csv,json");
+    protected String getUnlocalizedCommandUsage() {
+        return "commands.dumpmodores.usage";
     }
 
     @Override
-    public List getCommandAliases() {
-        return null;
+    protected int getFormatArgumentPosition() {
+        return 2;
+    }
+
+    @Nonnull
+    @Override
+    protected ImmutableList<String> getValidFormats() {
+        return FORMATS;
     }
 
     @Override
-    public void processCommand(ICommandSender sender, String[] args) {
-        if (!sender.getEntityWorld().isRemote) {
-            return;
-        }
+    protected int getRequiredNumberOfArguments() {
+        return 3;
+    }
 
-        if (args.length < 2)  {
-            throw new WrongUsageException("commands.dumpmodores.usage", "wiki,csv,json"); /* TODO */
-        }
+    @Nonnull
+    @Override
+    protected String getOutputFileName(String[] args) {
+        return args[0];
+    }
 
-        String abbreviation = args[0].toUpperCase();
-        String id = args[1];
-        String format = "wiki";
-        if (args.length == 3) {
-            if (args[2].equalsIgnoreCase("csv")) {
-                format = "csv";
-            } else if (args[2].equalsIgnoreCase("json")) {
-                format = "json";
-            }
-        }
+    @Nullable
+    @Override
+    protected String getModIDToSearch(String[] args) {
+        return args[1];
+    }
 
-        ArrayList<OreDictEntry> entries = OreDictDumperMod.getEntries(id);
-
-        String msg;
-        StringBuilder builder = new StringBuilder();
-        String extension = "txt";
-
-        switch (format) {
-            case "wiki": {
-                for (OreDictEntry entry : entries) {
-                    builder.append(String.format("%s!%s!%s!\n", entry.tagName, entry
-                      .displayName, abbreviation));
-                }
-                extension = "txt";
-                break;
+    @Nullable
+    @Override
+    protected OreDictOutputFormat getOutputFormat(String[] args) {
+        String formatArg = args[getFormatArgumentPosition()];
+        switch (formatArg) {
+            case "json": {
+                return new OreDictOutputFormat.JSONOutputFormat();
             }
             case "csv": {
-                builder.append("Tag,ItemName,Metadata,ModID\n");
-                for (OreDictEntry entry : entries) {
-                    builder.append(String.format("%s,%s,%s,%s\n", entry.tagName, entry.displayName,
-                      entry.metadata, entry.modID));
-                }
-                extension = "csv";
-                break;
+                return new OreDictOutputFormat.CSVOutputFormat();
             }
-            case "json": {
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                builder.append(gson.toJson(entries));
-                extension = "json";
-                break;
+            case "wiki": {
+                return new OreDictOutputFormat.WikiOutputFormat(args[0]);
             }
-            default: {}
+            default: {
+                return null;
+            }
         }
-
-        File dir = new File(Minecraft.getMinecraft().mcDataDir, String.format("%s.%s",
-          abbreviation, extension));
-        try {
-            FileWriter writer = new FileWriter(dir);
-            writer.write(builder.toString());
-            writer.close();
-            msg = EnumChatFormatting.GREEN + StatCollector.translateToLocalFormatted("commands.oredictdumpgeneric.success",
-              entries.size(), abbreviation, extension);
-        } catch (IOException e) {
-            e.printStackTrace();
-            System.out.println(entries.toString());
-            msg = EnumChatFormatting.RED + StatCollector.translateToLocal("commands.oredictdumpgeneric.ioexception");
-        }
-
-        sender.addChatMessage(new ChatComponentText(msg));
-    }
-
-    @Override
-    public boolean canCommandSenderUseCommand(ICommandSender sender) {
-        return true;
-    }
-
-    @Override
-    public List addTabCompletionOptions(ICommandSender sender, String[] options) {
-        return null;
-    }
-
-    @Override
-    public boolean isUsernameIndex(String[] args, int index) {
-        return false;
-    }
-
-    @Override
-    public int compareTo(@SuppressWarnings("NullableProblems") Object o) {
-        return 0;
     }
 }

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/commands/OreDumpCommandBase.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/commands/OreDumpCommandBase.java
@@ -1,0 +1,177 @@
+package com.gamepedia.ftb.oredictdumper.commands;
+
+import com.gamepedia.ftb.oredictdumper.misc.ChatStyleColored;
+import com.gamepedia.ftb.oredictdumper.misc.OreDictEntry;
+import com.gamepedia.ftb.oredictdumper.misc.OreDictOutputFormat;
+import com.google.common.collect.ImmutableList;
+import cpw.mods.fml.common.ModContainer;
+import cpw.mods.fml.common.registry.GameData;
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.*;
+import net.minecraftforge.oredict.OreDictionary;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class OreDumpCommandBase implements ICommand {
+    /**
+     * @return The base unlocalized string for the usage information of the command
+     */
+    @Nonnull
+    protected abstract String getUnlocalizedCommandUsage();
+
+    /**
+     * @return The position in a correctly formatted argument String array for the format argument
+     */
+    protected abstract int getFormatArgumentPosition();
+
+    /**
+     * @return An immutable list of valid format string arguments
+     */
+    @Nonnull
+    protected abstract ImmutableList<String> getValidFormats();
+
+    /**
+     * @return The number of arguments that are required for the command to be successfully executed
+     */
+    protected abstract int getRequiredNumberOfArguments();
+
+    /**
+     * @param args The list of arguments passed to the command
+     * @return The name of the file (not including the extension) to save as.
+     */
+    @Nonnull
+    protected abstract String getOutputFileName(String[] args);
+
+    /**
+     * @param args The list of arguments passed to the command
+     * @return The mod ID that is being searched (see {@link #getEntries(String)})
+     */
+    @Nullable
+    protected abstract String getModIDToSearch(String[] args);
+
+    /**
+     * @param args The list of arguments passed to the command
+     * @return The formatter to use for the arguments passed to the command
+     */
+    @Nullable
+    protected abstract OreDictOutputFormat getOutputFormat(String[] args);
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (!sender.getEntityWorld().isRemote) {
+            return;
+        }
+
+        if (args.length != getRequiredNumberOfArguments()) {
+            throw new WrongUsageException(getUnlocalizedCommandUsage(), StringUtils.join(getValidFormats(), ','));
+        }
+
+        String format = args[getFormatArgumentPosition()];
+        OreDictOutputFormat outputFormat = getOutputFormat(args);
+
+        if (!getValidFormats().contains(format) || outputFormat == null) {
+            throw new WrongUsageException(getUnlocalizedCommandUsage(), StringUtils.join(getValidFormats(), ','));
+        }
+
+        List<OreDictEntry> entries = getEntries(getModIDToSearch(args));
+        String fileName = getOutputFileName(args);
+        String ext = outputFormat.getFileExtension();
+        File dir = new File(Minecraft.getMinecraft().mcDataDir, String.format("%s.%s", fileName, ext));
+
+        IChatComponent msg;
+        try {
+            FileWriter writer = new FileWriter(dir);
+            writer.write(outputFormat.parseEntries(entries));
+            writer.close();
+            msg = new ChatComponentTranslation("commands.oredictdumpgeneric.success",
+              entries.size(), fileName, ext).setChatStyle(new ChatStyleColored(EnumChatFormatting.GREEN));
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.out.println(entries.toString());
+            msg = new ChatComponentTranslation("commands.oredictdumpgeneric.ioexception")
+              .setChatStyle(new ChatStyleColored(EnumChatFormatting.RED));
+        }
+
+        sender.addChatMessage(msg);
+    }
+
+    /**
+     * Returns an array of all the entries that are in the given mod ID.
+     * @param id The mod ID. Null if we don't want to narrow it down by mod ID (get all items)
+     * @return An array of OreDictEntries. Can be empty. Never null.
+     */
+    @Nonnull
+    private ArrayList<OreDictEntry> getEntries(@Nullable String id) {
+        ArrayList<OreDictEntry> entries = new ArrayList<>();
+        for (String name : OreDictionary.getOreNames()) {
+            for (ItemStack item : OreDictionary.getOres(name)) {
+                @SuppressWarnings("deprecation")
+                ModContainer mod = GameData.findModOwner(GameData.getItemRegistry().getNameForObject(item.getItem()));
+
+                String id1 = mod == null ? "minecraft" : mod.getModId();
+                if (id != null && !id.equals(id1)) {
+                    continue;
+                }
+
+                if (item.getItemDamage() == OreDictionary.WILDCARD_VALUE) {
+                    List list = new ArrayList();
+                    item.getItem().getSubItems(item.getItem(), null, list);
+                    for (Object obj : list) {
+                        // This will never happen assuming people are smart.
+                        if (!(obj instanceof ItemStack)) {
+                            continue;
+                        }
+                        ItemStack is = (ItemStack) obj;
+                        entries.add(new OreDictEntry(name, is.getDisplayName(), is.getItemDamage(), id1));
+                    }
+                } else {
+                    entries.add(new OreDictEntry(name, item.getDisplayName(), item.getItemDamage(), id1));
+                }
+            }
+        }
+
+        return entries;
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return StatCollector.translateToLocalFormatted(getUnlocalizedCommandUsage(), StringUtils.join(getValidFormats(), ','));
+    }
+
+    @Override
+    public List getCommandAliases() {
+        return null;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return true;
+    }
+
+    @Override
+    public List addTabCompletionOptions(ICommandSender sender, String[] options) {
+        return null;
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] args, int index) {
+        return false;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public int compareTo(Object o) {
+        return 0;
+    }
+}

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/commands/OreDumpCommandBase.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/commands/OreDumpCommandBase.java
@@ -11,7 +11,10 @@ import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.*;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.StringUtils;
 
@@ -84,7 +87,7 @@ public abstract class OreDumpCommandBase implements ICommand {
             throw new WrongUsageException(getUnlocalizedCommandUsage(), StringUtils.join(getValidFormats(), ','));
         }
 
-        List<OreDictEntry> entries = getEntries(getModIDToSearch(args));
+        ImmutableList<OreDictEntry> entries = getEntries(getModIDToSearch(args));
         String fileName = getOutputFileName(args);
         String ext = outputFormat.getFileExtension();
         File dir = new File(Minecraft.getMinecraft().mcDataDir, String.format("%s.%s", fileName, ext));
@@ -112,8 +115,8 @@ public abstract class OreDumpCommandBase implements ICommand {
      * @return An array of OreDictEntries. Can be empty. Never null.
      */
     @Nonnull
-    private ArrayList<OreDictEntry> getEntries(@Nullable String id) {
-        ArrayList<OreDictEntry> entries = new ArrayList<>();
+    private ImmutableList<OreDictEntry> getEntries(@Nullable String id) {
+        List<OreDictEntry> entries = new ArrayList<>();
         for (String name : OreDictionary.getOreNames()) {
             for (ItemStack item : OreDictionary.getOres(name)) {
                 @SuppressWarnings("deprecation")
@@ -141,7 +144,7 @@ public abstract class OreDumpCommandBase implements ICommand {
             }
         }
 
-        return entries;
+        return ImmutableList.copyOf(entries);
     }
 
     @Override

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/misc/ChatStyleColored.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/misc/ChatStyleColored.java
@@ -1,0 +1,17 @@
+package com.gamepedia.ftb.oredictdumper.misc;
+
+import net.minecraft.util.ChatStyle;
+import net.minecraft.util.EnumChatFormatting;
+
+public class ChatStyleColored extends ChatStyle {
+    private final EnumChatFormatting color;
+
+    public ChatStyleColored(EnumChatFormatting color) {
+        this.color = color;
+    }
+
+    @Override
+    public EnumChatFormatting getColor() {
+        return color;
+    }
+}

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/misc/OreDictEntry.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/misc/OreDictEntry.java
@@ -1,19 +1,44 @@
 package com.gamepedia.ftb.oredictdumper.misc;
 
-public class OreDictEntry {
-    public String tagName;
-    public String displayName;
-    public String modID;
-    public int metadata;
+import javax.annotation.Nonnull;
 
-    public OreDictEntry(String tag, String display, int meta, String mod) {
+public class OreDictEntry {
+    @Nonnull
+    private final String tagName;
+    @Nonnull
+    private final String displayName;
+    @Nonnull
+    private final String modID;
+    private final int metadata;
+
+    public OreDictEntry(@Nonnull String tag, @Nonnull String display, int meta, @Nonnull String mod) {
         tagName = tag;
         displayName = display;
         metadata = meta;
         modID = mod;
     }
 
+    @Nonnull
+    String getTagName() {
+        return tagName;
+    }
+
+    @Nonnull
+    String getDisplayName() {
+        return displayName;
+    }
+
+    @Nonnull
+    String getModID() {
+        return modID;
+    }
+
+    int getMetadata() {
+        return metadata;
+    }
+
+    @Override
     public String toString() {
-        return String.format("%s:%s@%s (%s)", modID, displayName, metadata, tagName);
+        return String.format("%s:%s@%s (%s)", getModID(), getDisplayName(), getMetadata(), getTagName());
     }
 }

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/misc/OreDictOutputFormat.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/misc/OreDictOutputFormat.java
@@ -1,10 +1,10 @@
 package com.gamepedia.ftb.oredictdumper.misc;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 
 public abstract class OreDictOutputFormat {
     private final String extension;
@@ -19,7 +19,7 @@ public abstract class OreDictOutputFormat {
     }
 
     @Nonnull
-    public abstract String parseEntries(List<OreDictEntry> entries);
+    public abstract String parseEntries(ImmutableList<OreDictEntry> entries);
 
     public static class JSONOutputFormat extends OreDictOutputFormat {
         public JSONOutputFormat() {
@@ -28,7 +28,7 @@ public abstract class OreDictOutputFormat {
 
         @Nonnull
         @Override
-        public String parseEntries(List<OreDictEntry> entries) {
+        public String parseEntries(ImmutableList<OreDictEntry> entries) {
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             return gson.toJson(entries);
         }
@@ -41,7 +41,7 @@ public abstract class OreDictOutputFormat {
 
         @Nonnull
         @Override
-        public String parseEntries(List<OreDictEntry> entries) {
+        public String parseEntries(ImmutableList<OreDictEntry> entries) {
             StringBuilder builder = new StringBuilder();
             builder.append("Tag,ItemName,Metadata,ModID\n");
             for (OreDictEntry entry : entries) {
@@ -61,7 +61,7 @@ public abstract class OreDictOutputFormat {
 
         @Nonnull
         @Override
-        public String parseEntries(List<OreDictEntry> entries) {
+        public String parseEntries(ImmutableList<OreDictEntry> entries) {
             StringBuilder builder = new StringBuilder();
             for (OreDictEntry entry : entries) {
                 builder.append(String.format("%s!%s!%s!\n", entry.getTagName(), entry.getDisplayName(), abbreviation));

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/misc/OreDictOutputFormat.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/misc/OreDictOutputFormat.java
@@ -1,0 +1,72 @@
+package com.gamepedia.ftb.oredictdumper.misc;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+public abstract class OreDictOutputFormat {
+    private final String extension;
+
+    OreDictOutputFormat(String extension) {
+        this.extension = extension;
+    }
+
+    @Nonnull
+    public String getFileExtension() {
+        return extension;
+    }
+
+    @Nonnull
+    public abstract String parseEntries(List<OreDictEntry> entries);
+
+    public static class JSONOutputFormat extends OreDictOutputFormat {
+        public JSONOutputFormat() {
+            super("json");
+        }
+
+        @Nonnull
+        @Override
+        public String parseEntries(List<OreDictEntry> entries) {
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            return gson.toJson(entries);
+        }
+    }
+
+    public static class CSVOutputFormat extends OreDictOutputFormat {
+        public CSVOutputFormat() {
+            super("csv");
+        }
+
+        @Nonnull
+        @Override
+        public String parseEntries(List<OreDictEntry> entries) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("Tag,ItemName,Metadata,ModID\n");
+            for (OreDictEntry entry : entries) {
+                builder.append(String.format("%s,%s,%s,%s\n", entry.tagName, entry.displayName, entry.metadata, entry.modID));
+            }
+            return builder.toString();
+        }
+    }
+
+    public static class WikiOutputFormat extends OreDictOutputFormat {
+        private final String abbreviation;
+
+        public WikiOutputFormat(String abbreviation) {
+            super("txt");
+            this.abbreviation = abbreviation;
+        }
+
+        @Nonnull
+        @Override
+        public String parseEntries(List<OreDictEntry> entries) {
+            StringBuilder builder = new StringBuilder();
+            for (OreDictEntry entry : entries) {
+                builder.append(String.format("%s!%s!%s!\n", entry.tagName, entry.displayName, abbreviation));
+            }
+            return builder.toString();
+        }
+    }
+}

--- a/src/main/java/com/gamepedia/ftb/oredictdumper/misc/OreDictOutputFormat.java
+++ b/src/main/java/com/gamepedia/ftb/oredictdumper/misc/OreDictOutputFormat.java
@@ -45,7 +45,7 @@ public abstract class OreDictOutputFormat {
             StringBuilder builder = new StringBuilder();
             builder.append("Tag,ItemName,Metadata,ModID\n");
             for (OreDictEntry entry : entries) {
-                builder.append(String.format("%s,%s,%s,%s\n", entry.tagName, entry.displayName, entry.metadata, entry.modID));
+                builder.append(String.format("%s,%s,%s,%s\n", entry.getTagName(), entry.getDisplayName(), entry.getMetadata(), entry.getModID()));
             }
             return builder.toString();
         }
@@ -64,7 +64,7 @@ public abstract class OreDictOutputFormat {
         public String parseEntries(List<OreDictEntry> entries) {
             StringBuilder builder = new StringBuilder();
             for (OreDictEntry entry : entries) {
-                builder.append(String.format("%s!%s!%s!\n", entry.tagName, entry.displayName, abbreviation));
+                builder.append(String.format("%s!%s!%s!\n", entry.getTagName(), entry.getDisplayName(), abbreviation));
             }
             return builder.toString();
         }


### PR DESCRIPTION
New OreDumpCommandBase abstract class for DumpAllOresCommand and DumpModOresCommand to inherit from. It provides some abstract methods needed for getting basic usage information on the commands, so that the base class can handle all of the :meat_on_bone: of the command execution.

New OreDictOutputFormat class for handling List<OreDictEntry> -> output text in a more concise, readable, and understandable way. It also allows for easily expanding/adding new output formats if we ever need to do that.

No longer output a ChatComponentText with a translated string to the chat, but a ChatComponentTranslation with its style set to a new ChatStyleColored generic class.

OreDictDumperMod.getEntries(String) is now OreDumpCommandBase#getEntries(String), which is a much more logical design.

The only downfall (although perhaps it is not actually much of a downfall, since there is no reason everyone should be assumed to use our specific wiki format) is that the /dumpmodores command now requires the format argument instead of assuming wiki.

If this is merged, I will make the exact same changes to the 1.8, 1.9, and 1.11 branches but won't submit a PR each time. The codebases are pretty much the same so the changes will be pretty much the same and I wouldn't want to make you review the same changes 4 times.